### PR TITLE
Fix/concurrent model loading

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,8 +13,8 @@
             <pattern>[%d{yyyy/MM/dd HH:mm:ss.SSS z} - %thread]%5p %logger.%M - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.juanitodread.pitayafinch" level="DEBUG"/>
-    <root level="DEBUG">
+    <logger name="org.juanitodread.pitayafinch" level="INFO"/>
+    <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -13,8 +13,8 @@
             <pattern>[%d{yyyy/MM/dd HH:mm:ss.SSS z} - %thread]%5p %logger.%M - %msg%n</pattern>
         </encoder>
     </appender>
-    <logger name="org.juanitodread.pitayafinch" level="INFO"/>
-    <root level="INFO">
+    <logger name="org.juanitodread.pitayafinch" level="DEBUG"/>
+    <root level="DEBUG">
         <appender-ref ref="stdout"/>
     </root>
 </configuration>

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizer.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizer.scala
@@ -2,11 +2,13 @@ package org.juanitodread.pitayafinch.nlp.tools.entities
 
 import opennlp.tools.namefind.NameFinderME
 import opennlp.tools.util.Span
-
 import org.juanitodread.pitayafinch.formatters.NumberFormatter
 import org.juanitodread.pitayafinch.model.nlp.entities.Entity
 import org.juanitodread.pitayafinch.nlp.tools.entities.models._
 import org.juanitodread.pitayafinch.nlp.tools.tokenize.Tokenizer
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 class EntityRecognizer[T <: Model](model: T) {
   private final val nameFinder: NameFinderME = new NameFinderME(model.getModel())
@@ -23,16 +25,16 @@ class EntityRecognizer[T <: Model](model: T) {
 
 object EntityRecognizer extends NumberFormatter {
   private final val recognizers = List(
-    new EntityRecognizer(DateEntityModel()),
-    new EntityRecognizer(LocationEntityModel()),
-    new EntityRecognizer(MoneyEntityModel()),
-    new EntityRecognizer(OrganizationEntityModel()),
-    new EntityRecognizer(PercentageEntityModel()),
-    new EntityRecognizer(PersonEntityModel()),
-    new EntityRecognizer(TimeEntityModel()))
+    DateEntityModelAsync(),
+    LocationEntityModelAsync(),
+    //MoneyEntityModelAsync(),
+    OrganizationEntityModelAsync(),
+    //PercentageEntityModelAsync(),
+    PersonEntityModelAsync(),
+    TimeEntityModelAsync()).map(futureModel => Await.result(futureModel, 5 seconds))
+    .map(model => new EntityRecognizer(model))
 
   def apply(sentence: String): List[Entity] = {
-    recognizers.map(_.find(sentence))
-      .flatMap(_.toList)
+    recognizers.map(_.find(sentence)).flatMap(_.toList)
   }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizer.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizer.scala
@@ -1,24 +1,25 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities
 
+import scala.concurrent.Await
+import scala.concurrent.duration._
 import opennlp.tools.namefind.NameFinderME
 import opennlp.tools.util.Span
+
 import org.juanitodread.pitayafinch.formatters.NumberFormatter
 import org.juanitodread.pitayafinch.model.nlp.entities.Entity
 import org.juanitodread.pitayafinch.nlp.tools.entities.models._
 import org.juanitodread.pitayafinch.nlp.tools.tokenize.Tokenizer
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
-
-class EntityRecognizer[T <: Model](model: T) {
-  private final val nameFinder: NameFinderME = new NameFinderME(model.getModel())
-
+class EntityRecognizer[T <: Model](model: T) extends NumberFormatter {
   def find(sentence: String): List[Entity] = {
+    val nameFinder: NameFinderME = new NameFinderME(model.getModel())
     val tokens: Array[String] = Tokenizer.maxEntropy(sentence).toArray[String]
     val spans: Array[Span] = nameFinder.find(tokens)
+    nameFinder.clearAdaptiveData()
+
     spans.map { span =>
       val entityName = tokens.slice(span.getStart, span.getEnd).mkString(" ")
-      Entity(entityName, model.getName(), EntityRecognizer.round(span.getProb))
+      Entity(entityName, model.getName(), round(span.getProb))
     }.toList
   }
 }
@@ -27,9 +28,9 @@ object EntityRecognizer extends NumberFormatter {
   private final val recognizers = List(
     DateEntityModelAsync(),
     LocationEntityModelAsync(),
-    //MoneyEntityModelAsync(),
+    MoneyEntityModelAsync(),
     OrganizationEntityModelAsync(),
-    //PercentageEntityModelAsync(),
+    PercentageEntityModelAsync(),
     PersonEntityModelAsync(),
     TimeEntityModelAsync()).map(futureModel => Await.result(futureModel, 5 seconds))
     .map(model => new EntityRecognizer(model))

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/DateEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/DateEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class DateEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-date.bin") {
   override def getName(): String = "Date"
@@ -8,4 +11,10 @@ class DateEntityModel
 object DateEntityModel {
   private val model: DateEntityModel = new DateEntityModel()
   def apply(): DateEntityModel = model
+}
+
+object DateEntityModelAsync {
+  def apply(): Future[DateEntityModel] = Future[DateEntityModel] {
+    new DateEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/LocationEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/LocationEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class LocationEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-location.bin") {
   override def getName(): String = "Location"
@@ -8,4 +11,10 @@ class LocationEntityModel
 object LocationEntityModel {
   private val model: LocationEntityModel = new LocationEntityModel()
   def apply(): LocationEntityModel = model
+}
+
+object LocationEntityModelAsync {
+  def apply(): Future[LocationEntityModel] = Future[LocationEntityModel] {
+    new LocationEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/Model.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/Model.scala
@@ -11,7 +11,7 @@ trait Model {
 }
 
 abstract class AbstractModel(modelPath: String) extends Model {
-  private val logger: Logger = LoggerFactory.getLogger(getClass)
+  private final val logger: Logger = LoggerFactory.getLogger(getClass)
 
   logger.info(s"Reading Entity Recognizer model from: ${modelPath}")
   protected val modelFile: InputStream = getClass.getResourceAsStream(modelPath)

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/MoneyEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/MoneyEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class MoneyEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-money.bin") {
   override def getName(): String = "Money"
@@ -8,4 +11,10 @@ class MoneyEntityModel
 object MoneyEntityModel {
   private val model: MoneyEntityModel = new MoneyEntityModel()
   def apply(): MoneyEntityModel = model
+}
+
+object MoneyEntityModelAsync {
+  def apply(): Future[MoneyEntityModel] = Future[MoneyEntityModel] {
+    new MoneyEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/OrganizationEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/OrganizationEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class OrganizationEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-organization.bin") {
   override def getName(): String = "Organization"
@@ -8,4 +11,10 @@ class OrganizationEntityModel
 object OrganizationEntityModel {
   private val model: OrganizationEntityModel = new OrganizationEntityModel()
   def apply(): OrganizationEntityModel = model
+}
+
+object OrganizationEntityModelAsync {
+  def apply(): Future[OrganizationEntityModel] = Future[OrganizationEntityModel] {
+    new OrganizationEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/PercentageEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/PercentageEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class PercentageEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-percentage.bin") {
   override def getName(): String = "Percentage"
@@ -8,4 +11,10 @@ class PercentageEntityModel
 object PercentageEntityModel {
   private val model: PercentageEntityModel = new PercentageEntityModel()
   def apply(): PercentageEntityModel = model
+}
+
+object PercentageEntityModelAsync {
+  def apply(): Future[PercentageEntityModel] = Future[PercentageEntityModel] {
+    new PercentageEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/PersonEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/PersonEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class PersonEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-person.bin") {
   override def getName(): String = "Person"
@@ -8,4 +11,10 @@ class PersonEntityModel
 object PersonEntityModel {
   private val model: PersonEntityModel = new PersonEntityModel()
   def apply(): PersonEntityModel = model
+}
+
+object PersonEntityModelAsync {
+  def apply(): Future[PersonEntityModel] = Future[PersonEntityModel] {
+    new PersonEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/TimeEntityModel.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/entities/models/TimeEntityModel.scala
@@ -1,5 +1,8 @@
 package org.juanitodread.pitayafinch.nlp.tools.entities.models
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class TimeEntityModel
   extends AbstractModel("/nlp/models/entities/en-ner-time.bin") {
   override def getName(): String = "Time"
@@ -8,4 +11,10 @@ class TimeEntityModel
 object TimeEntityModel {
   private val model: TimeEntityModel = new TimeEntityModel()
   def apply(): TimeEntityModel = model
+}
+
+object TimeEntityModelAsync {
+  def apply(): Future[TimeEntityModel] = Future[TimeEntityModel] {
+    new TimeEntityModel()
+  }
 }

--- a/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/tokenize/Tokenizer.scala
+++ b/src/main/scala/org/juanitodread/pitayafinch/nlp/tools/tokenize/Tokenizer.scala
@@ -6,13 +6,13 @@ import opennlp.tools.tokenize.{
   TokenizerModel,
   WhitespaceTokenizer
 }
+import org.slf4j.{ Logger, LoggerFactory }
 
 import org.juanitodread.pitayafinch.model.nlp.tokenizer.Tokenizers._
 
 object Tokenizer {
   private final val simpleTokenizer = SimpleTokenizer.INSTANCE
   private final val whitespaceTokenizer = WhitespaceTokenizer.INSTANCE
-  private final val maxEntropyTokenizer = new TokenizerME(MaxEntropyModel.instance())
 
   def simple(paragraph: String): List[String] = {
     simpleTokenizer.tokenize(paragraph).toList
@@ -23,6 +23,7 @@ object Tokenizer {
   }
 
   def maxEntropy(paragraph: String): List[String] = {
+    val maxEntropyTokenizer = new TokenizerME(MaxEntropyModel.instance())
     maxEntropyTokenizer.tokenize(paragraph).toList
   }
 
@@ -34,10 +35,13 @@ object Tokenizer {
 }
 
 object MaxEntropyModel {
+  private final val logger: Logger = LoggerFactory.getLogger(getClass)
   final val MODEL_PATH = "/nlp/models/tokenizer/en-token.bin"
 
+  logger.info(s"Reading TokenizerModel model from: $MODEL_PATH")
   private final val modelFile = getClass.getResourceAsStream(MODEL_PATH)
   private final val model = new TokenizerModel(modelFile)
+  logger.info(s"TokenizerModel model loaded from: $MODEL_PATH")
 
   def instance(): TokenizerModel = {
     model

--- a/src/test/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizerSpec.scala
+++ b/src/test/scala/org/juanitodread/pitayafinch/nlp/tools/entities/EntityRecognizerSpec.scala
@@ -2,7 +2,8 @@ package org.juanitodread.pitayafinch.nlp.tools.entities
 
 import org.juanitodread.pitayafinch.UnitSpec
 import org.juanitodread.pitayafinch.model.nlp.entities.Entity
-import org.juanitodread.pitayafinch.nlp.tools.entities.models.{ OrganizationEntityModel, PersonEntityModel }
+import org.juanitodread.pitayafinch.nlp.tools.entities.fixtures.EntityRecognizerFixture
+import org.juanitodread.pitayafinch.nlp.tools.entities.models._
 
 class EntityRecognizerSpec extends UnitSpec {
   val sentence = "However, real progress was much slower, and after the ALPAC report in 1966, which found " +
@@ -30,32 +31,32 @@ class EntityRecognizerSpec extends UnitSpec {
   }
 
   "An EntityRecognizer object" should "be able to evaluate DateEntityModel" in {
-    val entity = EntityRecognizer("This is a date: Nov 12 1993").head
+    val entity = EntityRecognizerFixture("This is a date: Nov 12 1993").head
     assert(entity.entity === "Nov 12 1993")
     assert(entity.model === "Date")
   }
 
   it should "be able to evaluate LocationEntityModel" in {
-    val entity = EntityRecognizer("This is a location: California").head
+    val entity = EntityRecognizerFixture("This is a location: California").head
     assert(entity.entity === "California")
     assert(entity.model === "Location")
   }
 
   it should "be able to evaluate MoneyEntityModel" in {
     // In Money 2 entities are returned always. (First one with '$' only)
-    val entity = EntityRecognizer("This is currency money: $45.50").tail.head
+    val entity = EntityRecognizerFixture("This is currency money: $45.50").tail.head
     assert(entity.entity === "45.50")
     assert(entity.model === "Money")
   }
 
   it should "be able to evaluate OrganizationEntityModel" in {
-    val entity = EntityRecognizer("This is an organization: IBM").head
+    val entity = EntityRecognizerFixture("This is an organization: IBM").head
     assert(entity.entity === "IBM")
     assert(entity.model === "Organization")
   }
 
   it should "be able to evaluate PersonEntityModel" in {
-    val entity = EntityRecognizer("This is a person: Julian Casablancas").head
+    val entity = EntityRecognizerFixture("This is a person: Julian Casablancas").head
     assert(entity.entity === "Julian Casablancas")
     assert(entity.model === "Person")
   }

--- a/src/test/scala/org/juanitodread/pitayafinch/nlp/tools/entities/fixtures/EntityRecognizerFixture.scala
+++ b/src/test/scala/org/juanitodread/pitayafinch/nlp/tools/entities/fixtures/EntityRecognizerFixture.scala
@@ -1,0 +1,22 @@
+package org.juanitodread.pitayafinch.nlp.tools.entities.fixtures
+
+import org.juanitodread.pitayafinch.formatters.NumberFormatter
+import org.juanitodread.pitayafinch.model.nlp.entities.Entity
+import org.juanitodread.pitayafinch.nlp.tools.entities.EntityRecognizer
+import org.juanitodread.pitayafinch.nlp.tools.entities.models._
+
+object EntityRecognizerFixture extends NumberFormatter {
+  println("ENTRE AL FIXTURE: EntityRecognizerFixture")
+  private final val recognizers = List(
+    DateEntityModel(),
+    LocationEntityModel(),
+    MoneyEntityModel(),
+    OrganizationEntityModel(),
+    PercentageEntityModel(),
+    PersonEntityModel(),
+    TimeEntityModel()).map(model => new EntityRecognizer(model))
+
+  def apply(sentence: String): List[Entity] = {
+    recognizers.map(_.find(sentence)).flatMap(_.toList)
+  }
+}

--- a/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/EntitiesEndpointSpec.scala
+++ b/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/EntitiesEndpointSpec.scala
@@ -6,7 +6,7 @@ import io.finch.Input
 import io.finch.circe._
 
 import org.juanitodread.pitayafinch.UnitSpec
-import org.juanitodread.pitayafinch.model.nlp.entities.{ EntitiesRequest, EntitiesResponse, Entity }
+import org.juanitodread.pitayafinch.model.nlp.entities._
 
 class EntitiesEndpointSpec extends UnitSpec {
   private val baseApi: String = "/pitaya/api/v1/nlp/entities"

--- a/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/EntitiesEndpointSpec.scala
+++ b/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/EntitiesEndpointSpec.scala
@@ -7,13 +7,14 @@ import io.finch.circe._
 
 import org.juanitodread.pitayafinch.UnitSpec
 import org.juanitodread.pitayafinch.model.nlp.entities._
+import org.juanitodread.pitayafinch.routes.nlp.tools.entities.fixtures.EntitiesEndpointFixture
 
 class EntitiesEndpointSpec extends UnitSpec {
   private val baseApi: String = "/pitaya/api/v1/nlp/entities"
 
   "A EntitiesEndpoint" should "have a getEntities endpoint" in {
     val request = EntitiesRequest("He appointed Julian Casablancas")
-    EntitiesEndpoint.getEntities().apply(Input.post(baseApi).withBody[Json](request)).awaitValueUnsafe().get shouldEqual {
+    EntitiesEndpointFixture.getEntities().apply(Input.post(baseApi).withBody[Json](request)).awaitValueUnsafe().get shouldEqual {
       EntitiesResponse(
         "He appointed Julian Casablancas",
         List(Entity("Julian Casablancas", "Person", 0.939)))

--- a/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/fixtures/EntitiesEndpointFixture.scala
+++ b/src/test/scala/org/juanitodread/pitayafinch/routes/nlp/tools/entities/fixtures/EntitiesEndpointFixture.scala
@@ -1,4 +1,4 @@
-package org.juanitodread.pitayafinch.routes.nlp.tools.entities
+package org.juanitodread.pitayafinch.routes.nlp.tools.entities.fixtures
 
 import cats.effect.IO
 import io.circe.generic.auto._
@@ -7,16 +7,17 @@ import io.finch.catsEffect._
 import io.finch.circe._
 
 import org.juanitodread.pitayafinch.model.nlp.entities._
-import org.juanitodread.pitayafinch.nlp.tools.entities._
+import org.juanitodread.pitayafinch.nlp.tools.entities.fixtures.EntityRecognizerFixture
 import org.juanitodread.pitayafinch.routes.nlp.NlpEndpoint
 
-object EntitiesEndpoint extends NlpEndpoint {
+object EntitiesEndpointFixture extends NlpEndpoint {
   private final val entitiesPath = basePath :: "entities"
 
   private val postedEntities: Endpoint[IO, EntitiesRequest] = jsonBody[EntitiesRequest]
   def getEntities(): Endpoint[IO, EntitiesResponse] = post(entitiesPath :: postedEntities) { request: EntitiesRequest =>
     Ok(EntitiesResponse(
       request.text,
-      EntityRecognizer(request.text)))
+      EntityRecognizerFixture(request.text)))
   }
 }
+

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=12


### PR DESCRIPTION
Fixes #58 
* Add config file to use JDK12
* Entity Recognition models are loaded in parallel in order to reduce loading time.
* Add new fixtures to load models in sequence order in order to avoid raise conditions in tests.
* Some fixes when using OpenNLP in multithread env. to avoid raise conditions.